### PR TITLE
Correct spelling of "principal"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Overview
 
 The hacluster subordinate charm provides corosync and pacemaker cluster
-configuration for principle charms which support the hacluster, container
+configuration for principal charms which support the hacluster, container
 scoped relation.
 
 The charm will only configure for HA once more that one service unit is
@@ -26,7 +26,7 @@ To enable HA clustering support (for mysql for example):
     juju add-relation mysql ceph
     juju add-relation mysql mysql-hacluster
 
-The principle charm must have explicit support for the hacluster interface
+The principal charm must have explicit support for the hacluster interface
 in order for clustering to occur - otherwise nothing actually get configured.
 
 # Settings
@@ -69,14 +69,14 @@ options.
 
 ## Mandatory Relation Data (deprecated)
 
-Principle charms should provide basic corosync configuration:
+Principal charms should provide basic corosync configuration:
 
     corosync\_bindiface: The network interface to use for cluster messaging.
     corosync\_mcastport: The multicast port to use for cluster messaging.
 
 however, these can also be provided via configuration on the hacluster charm
 itself.  If configuration is provided directly to the hacluster charm, this
-will be preferred over these relation options from the principle charm.
+will be preferred over these relation options from the principal charm.
 
 ## Resource Configuration
 

--- a/hooks/charmhelpers/contrib/openstack/utils.py
+++ b/hooks/charmhelpers/contrib/openstack/utils.py
@@ -1215,9 +1215,9 @@ def remote_restart(rel_name, remote_service=None):
     if remote_service:
         trigger['remote-service'] = remote_service
     for rid in relation_ids(rel_name):
-        # This subordinate can be related to two seperate services using
+        # This subordinate can be related to two separate services using
         # different subordinate relations so only issue the restart if
-        # the principle is conencted down the relation we think it is
+        # the principal is connected down the relation we think it is
         if related_units(relid=rid):
             relation_set(relation_id=rid,
                          relation_settings=trigger,

--- a/hooks/charmhelpers/core/hookenv.py
+++ b/hooks/charmhelpers/core/hookenv.py
@@ -240,7 +240,7 @@ def principal_unit():
         return os.environ['JUJU_UNIT_NAME']
     elif principal_unit is not None:
         return principal_unit
-    # For Juju 2.1 and below, let's try work out the principle unit by
+    # For Juju 2.1 and below, let's try work out the principal unit by
     # the various charms' metadata.yaml.
     for reltype in relation_types():
         for rid in relation_ids(reltype):

--- a/hooks/hooks.py
+++ b/hooks/hooks.py
@@ -217,7 +217,7 @@ def hanode_relation_joined(relid=None):
             'ha-relation-changed',
             'hanode-relation-changed')
 def ha_relation_changed():
-    # Check that we are related to a principle and that
+    # Check that we are related to a principal and that
     # it has already provided the required corosync configuration
     if not get_corosync_conf():
         log('Unable to configure corosync right now, deferring configuration',
@@ -245,7 +245,7 @@ def ha_relation_changed():
         relid = relids[0]
         units = related_units(relid)
         if len(units) < 1:
-            log('No principle unit found, deferring configuration',
+            log('No principal unit found, deferring configuration',
                 level=INFO)
             return
 

--- a/hooks/utils.py
+++ b/hooks/utils.py
@@ -229,7 +229,7 @@ def get_corosync_conf():
     transport = get_transport()
 
     # NOTE(jamespage) use local charm configuration over any provided by
-    # principle charm
+    # principal charm
     conf = {
         'ip_version': ip_version,
         'ha_nodes': get_ha_nodes(),


### PR DESCRIPTION
Charms and units may be "principal" (primary), not "principle" (a rule
or a guiding belief).